### PR TITLE
remove thread and disable stop when migrate

### DIFF
--- a/migration/channel.h
+++ b/migration/channel.h
@@ -25,6 +25,11 @@ void migration_channel_connect(MigrationState *s,
                                const char *hostname,
                                Error *error_in);
 
+void migration_channel_connect_without_thread(MigrationState *s,
+                               QIOChannel *ioc,
+                               const char *hostname,
+                               Error *error_in);
+
 int migration_channel_read_peek(QIOChannel *ioc,
                                 const char *buf,
                                 const size_t buflen,

--- a/migration/file.h
+++ b/migration/file.h
@@ -17,6 +17,8 @@ void file_start_incoming_migration(FileMigrationArgs *file_args, Error **errp);
 
 void file_start_outgoing_migration(MigrationState *s,
                                    FileMigrationArgs *file_args, Error **errp);
+void file_start_outgoing_migration_without_thread(MigrationState *s,
+                                   FileMigrationArgs *file_args, Error **errp);
 int file_parse_offset(char *filespec, uint64_t *offsetp, Error **errp);
 void file_cleanup_outgoing_migration(void);
 bool file_send_channel_create(gpointer opaque, Error **errp);

--- a/migration/migration.h
+++ b/migration/migration.h
@@ -472,6 +472,7 @@ void migrate_set_error(MigrationState *s, const Error *error);
 bool migrate_has_error(MigrationState *s);
 
 void migrate_fd_connect(MigrationState *s, Error *error_in);
+void migrate_fd_connect_without_thread(MigrationState *s, Error *error_in);
 
 int migration_call_notifiers(MigrationState *s, MigrationEventType type,
                              Error **errp);

--- a/target/i386/kvm/kvm.c
+++ b/target/i386/kvm/kvm.c
@@ -6034,6 +6034,10 @@ extern void qmp_migrate(const char *uri, bool has_channels,
                  MigrationChannelList *channels, bool has_detach, bool detach,
                  bool has_resume, bool resume, Error **errp);
 
+extern void forkd_migrate(const char *uri, bool has_channels,
+                 MigrationChannelList *channels, bool has_detach, bool detach,
+                 bool has_resume, bool resume, Error **errp);
+
 /*
  * 1. Boot a new vm with -forked flag, the new vm will waiting for incoming 
  *    data.
@@ -6116,8 +6120,10 @@ static int kvm_handle_hc_fork_vm(struct kvm_run *run)
     sprintf(uri, "file:%s/%s", migrate_path, migrate_filename);
     MigrationState *s = migrate_get_current();
     s->hostname = g_strdup("forkhost");
-    qmp_migrate(uri, false, NULL, false, false, false, false, &err);
-    pause();
+//    qmp_migrate(uri, false, NULL, false, false, false, false, &err);
+//    pause();
+
+    forkd_migrate(uri, false, NULL, false, false, false, false, &err);
     /* Return child pid */
     return child_pid;
 }


### PR DESCRIPTION
去掉了原来的迁移线程，直接将迁移逻辑放在主线程，在migrate_fd_connect_without_thread中的do_migration_work。
在迁移逻辑中删除了停止调用VM的逻辑，在migration_stop_vm_without_stopvm处。

然后在构建qemu的时候需要在build文件夹中的qapi/qapi-commands-migration.h文件添加forkd_migrate声明，否则编译的时候报错：
![image](https://github.com/user-attachments/assets/8715fd78-ccaa-43ba-931f-81f4ec2e4a88)
